### PR TITLE
Remove default strategy for service worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/plugin-service-worker.js
+++ b/src/plugin-service-worker.js
@@ -40,8 +40,6 @@ if (typeof workbox !== "undefined") {
     new workbox.strategies.StaleWhileRevalidate()
   );
 
-  workbox.routing.setDefaultHandler(new workbox.strategies.NetworkOnly());
-
   caches.open(workbox.core.cacheNames.runtime).then(function(cache) {
     cache.keys().then(function(requests) {
       var urls = requests.map(function(request) {


### PR DESCRIPTION
This PR is a fix for the default network strategy for the service worker, the user won't be able to connect to my binder for the first time.