### PR TITLE
Fix dialog close bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/windowManager.js
+++ b/src/windowManager.js
@@ -213,7 +213,7 @@ export class WindowManager {
         this.windows.push(w);
         this.window_ids[w.id] = w;
         this.setupCallbacks(w);
-        this.selectWindow(w, w.dialog);
+        if (!w.dialog) this.selectWindow(w, w.dialog);
         if (this.add_window_callback) {
           Promise.resolve(this.add_window_callback(w)).then(() => {
             this.event_bus.emit("add_window", w);


### PR DESCRIPTION
Currently, if there is a window in standalone mode, closing a dialog can make it unselected and disappear which can be very confusing.