### PR TITLE
Add lib to serviceworker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/plugin-service-worker.js
+++ b/src/plugin-service-worker.js
@@ -30,6 +30,11 @@ if (typeof workbox !== "undefined") {
     new workbox.strategies.StaleWhileRevalidate()
   );
 
+  workbox.routing.registerRoute(
+    new RegExp("(http|https)://lib.imjoy.io/.*"),
+    new workbox.strategies.StaleWhileRevalidate()
+  );
+
   var cached_keys = new Set();
   function matchCb(request) {
     return cached_keys.has(request.url.href);


### PR DESCRIPTION
The JailedSite file hosted on lib.imjoy.io is missing from the serviceworker and ImJoy stopped working offline.

This is a fix for that.