### PR TITLE
Add keywords file/ndarray to the schema

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function (config) {
         files: [
             // only specify one entry point
             // and require all tests in there
-            'tests/index_test.js',
+            'tests/*_test.js',
             { pattern: 'src/jailed/*', watched: false, included: false, served: true, nocache: false },
             { pattern: 'src/*.js', watched: false, included: false, served: true, nocache: false },
         ],
@@ -38,7 +38,7 @@ module.exports = function (config) {
         // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
         preprocessors: {
         // add webpack as preprocessor
-        'tests/index_test.js': ['webpack']
+        'tests/*_test.js': ['webpack']
         },
 
         webpack: webpackConfig,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.11.17",
+  "version": "0.11.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.11.17",
+  "version": "0.11.18",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/imjoyCore.js
+++ b/src/imjoyCore.js
@@ -12,6 +12,7 @@ import { randId } from "./utils.js";
 import Minibus from "minibus";
 
 export { Joy } from "./joy";
+export { ajv } from "./api";
 
 import * as _utils from "./utils.js";
 export const utils = _utils;

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -34,13 +34,11 @@ import {
   PLUGIN_SCHEMA,
   CONFIGURABLE_FIELDS,
   upgradePluginAPI,
+  ajv,
 } from "./api.js";
 
 import { Joy } from "./joy";
 import { saveAs } from "file-saver";
-
-import Ajv from "ajv";
-const ajv = new Ajv();
 
 export class PluginManager {
   constructor({

--- a/src/windowManager.js
+++ b/src/windowManager.js
@@ -77,7 +77,7 @@ export class WindowManager {
           try {
             const loader_key = this.registered_inputs[k].loader_key;
             if (this.registered_loaders[loader_key]) {
-              loaders[loader_key] = loader_key;
+              loaders[loader_key] = this.registered_loaders[loader_key];
             }
           } catch (e) {
             console.error("Failed to get loaders.", e);
@@ -201,7 +201,7 @@ export class WindowManager {
     return new Promise((resolve, reject) => {
       try {
         w.id = w.id || w.name + randId();
-        w.loaders = this.getDataLoaders(w.data);
+        w.loaders = {}; // this.getDataLoaders(w.data);
         if (!w.dialog) this.generateGridPosition(w);
         if (w.standalone) {
           w.h = 0;

--- a/src/windowManager.js
+++ b/src/windowManager.js
@@ -201,7 +201,6 @@ export class WindowManager {
     return new Promise((resolve, reject) => {
       try {
         w.id = w.id || w.name + randId();
-        w.loaders = {}; // this.getDataLoaders(w.data);
         if (!w.dialog) this.generateGridPosition(w);
         if (w.standalone) {
           w.h = 0;

--- a/tests/ajv_test.js
+++ b/tests/ajv_test.js
@@ -1,0 +1,161 @@
+import { ajv } from "../src/imjoyCore.js";
+import { expect } from "chai";
+
+describe("ajv", async () => {
+  let schema;
+  const data = {
+    mydata: {
+      __jailed_type__: "ndarray",
+      __value__: new Uint8Array(new ArrayBuffer(100)),
+      __shape__: [10, 10],
+      __dtype__: "uint8",
+    },
+    myfile: new File(["foo"], "foo.txt", {
+      type: "text/plain",
+    }),
+  };
+  it("should validate ndarray", async () => {
+    // correct shape
+    schema = {
+      properties: {
+        mydata: { ndarray: { shape: [10, 10] } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.true;
+
+    // wrong shape
+    schema = {
+      properties: {
+        mydata: { ndarray: { shape: [20, 10] } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.false;
+
+    // wrong dtype
+    schema = {
+      properties: {
+        mydata: { ndarray: { dtype: "float32" } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.false;
+
+    // correct dtype
+    schema = {
+      properties: {
+        mydata: { ndarray: { dtype: "uint8" } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.true;
+
+    // correct dtype list
+    schema = {
+      properties: {
+        mydata: { ndarray: { dtype: ["uint8", "float32"] } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.true;
+
+    // wrong ndim
+    schema = {
+      properties: {
+        mydata: { ndarray: { ndim: 3 } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.false;
+
+    // correct ndim
+    schema = {
+      properties: {
+        mydata: { ndarray: { ndim: 2 } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.true;
+
+    // correct ndim list
+    schema = {
+      properties: {
+        mydata: { ndarray: { ndim: [2, 3] } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.true;
+
+    // wrong ndim list
+    schema = {
+      properties: {
+        mydata: { ndarray: { ndim: [1, 3] } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.false;
+
+    // simple array
+    schema = { ndarray: {} };
+    expect(
+      ajv.compile(schema)({
+        __jailed_type__: "ndarray",
+        __value__: new Uint8Array(new ArrayBuffer(10)),
+        __shape__: [1, 10],
+        __dtype__: "uint8",
+      })
+    ).to.be.true;
+
+    // undefined shape
+    schema = { ndarray: { shape: [null, null] } };
+    expect(
+      ajv.compile(schema)({
+        __jailed_type__: "ndarray",
+        __value__: new Uint8Array(new ArrayBuffer(10)),
+        __shape__: [1, 10],
+        __dtype__: "uint8",
+      })
+    ).to.be.true;
+  });
+
+  it("should validate file", async () => {
+    // correct mime
+    schema = {
+      properties: {
+        myfile: { file: { mime: "text/plain" } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.true;
+
+    // correct mime list
+    schema = {
+      properties: {
+        myfile: { file: { mime: ["text/plain", "image/png"] } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.true;
+    // wrong mime
+    schema = {
+      properties: {
+        myfile: { file: { mime: "image/png" } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.false;
+
+    // wrong ext
+    schema = {
+      properties: {
+        myfile: { file: { ext: "png" } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.false;
+
+    // correct ext
+    schema = {
+      properties: {
+        myfile: { file: { ext: "txt" } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.true;
+
+    // correct ext list
+    schema = {
+      properties: {
+        myfile: { file: { ext: ["txt", "png"] } },
+      },
+    };
+    expect(ajv.compile(schema)(data)).to.be.true;
+  });
+});


### PR DESCRIPTION
This PR add two keywords to the ajv schema, so one can easily validate file types and ndarray.

For example you can now set `{ file: { mime: ["text/plain", "image/png"] } }` or `{ ndarray: { dtype: ["uint8", "float32"] , shape: [512, 512]} }` for `inputs` in `<config>` block.

