### PR TITLE
Use cdn instead of github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Or, you can inject the ImJoy runtime into your web application, such that it can
 <script src="https://lib.imjoy.io/imjoy-loader.min.js"></script>
 
 <script>
-loadImJoyCore().then((imjoyCore)=>{
+imjoyLoader.loadImJoyCore().then((imjoyCore)=>{
     const imjoy = new imjoyCore.ImJoy({
         imjoy_api: {},
         //imjoy config
@@ -37,7 +37,7 @@ loadImJoyCore().then((imjoyCore)=>{
 ```
 A full example html file can be found [here](/src/core-example.html).
 
-Note: To improve reproducibility in production, you should specify the `version` for the core by calling for example `loadImJoyCore({version: "0.12.0"})`.
+Note: To improve reproducibility in production, you should specify the `version` for the core by calling for example `imjoyLoader.loadImJoyCore({version: "0.12.0"})`.
 
 #### Option 2: Use the npm module
 
@@ -73,7 +73,7 @@ You can easily support by loading the ImJoy Remote Procedure Call(RPC) runtime, 
 <script src="https://lib.imjoy.io/imjoy-loader.min.js"></script>
 
 <script>
-loadImJoyRPC().then(async (imjoyRPC)=>{
+imjoyLoader.loadImJoyRPC().then(async (imjoyRPC)=>{
     const api = await imjoyRPC.setupRPC();
     function setup(){
         api.alert('ImJoy RPC initialized.')
@@ -87,7 +87,7 @@ loadImJoyRPC().then(async (imjoyRPC)=>{
 })
 </script>
 ```
-Note: To improve reproducibility in production, you should specify the `api_version` (or pin to a specific `version`) by calling for example `loadImJoyRPC({api_version: "0.2.0"})`.
+Note: To improve reproducibility in production, you should specify the `api_version` (or pin to a specific `version`) by calling for example `imjoyLoader.loadImJoyRPC({api_version: "0.2.0"})`.
 
 Alternatively, you can load the imjoy-rpc library via cdn `https://cdn.jsdelivr.net/npm/imjoy-rpc@latest/dist/imjoy-rpc.min.js` (or replace `@latest` to a version number). Using the the imjoy-loader will be more flexible since it only load when you call the load function.
 
@@ -142,21 +142,23 @@ we provide a function to enable automatic swithching between the two modes by de
 ```js
 // check if it's inside an iframe
 if(window.self !== window.top){
-    loadImJoyRPC().then((imjoyRPC)=>{
+    imjoyLoader.loadImJoyRPC().then((imjoyRPC)=>{
         
     })
 }
 else {
-    loadImJoyCore().then((imjoyCore)=>{
+    imjoyLoader.loadImJoyCore().then((imjoyCore)=>{
 
     })
 }
 ```
 
 ### API options
-For all three api function (`loadImJoyRPC`, `loadImJoyCore`), you can optinally pass a `config` object contains the following options:
+For the loader functions (`imjoyLoader.loadImJoyRPC`, `imjoyLoader.loadImJoyCore`), you can optinally pass a `config` object contains the following options:
  * `version`: specify the `imjoy-core` or `imjoy-rpc` library version
+ * `api_version`: for `imjoy-rpc` only, to contrain the api version of the RPC
  * `debug`: load the full `imjoy-core` version instead of a minified version, useful for debugging
+ * `base_url`: a custom url for loading the libraries
 
 ## Examples for using the ImJoy Core
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/base_frame.html
+++ b/src/base_frame.html
@@ -1,5 +1,5 @@
 <script
   type="text/javascript"
   onload="imjoyRPC.setupBaseFrame()"
-  src="https://lib.imjoy.io/imjoy-rpc.min.js"
+  src="https://cdn.jsdelivr.net/npm/imjoy-rpc@latest/dist/imjoy-rpc.min.js"
 ></script>

--- a/src/core-example.html
+++ b/src/core-example.html
@@ -8,7 +8,7 @@
     <h1>ImJoy Core Example</h1>
     <script src="https://lib.imjoy.io/imjoy-loader.min.js"></script>
     <script>
-      loadImJoyCore().then(imjoyCore => {
+      imjoyLoader.loadImJoyCore().then(imjoyCore => {
         console.log(imjoyCore);
         const imjoy = new imjoyCore.ImJoy({
           imjoy_api: {},

--- a/src/imjoyLoader.js
+++ b/src/imjoyLoader.js
@@ -26,13 +26,8 @@ export function loadImJoyCore(config) {
     try {
       var baseUrl = config.base_url;
       if (!baseUrl) {
-        if (config.version) {
-          baseUrl = `https://cdn.jsdelivr.net/npm/imjoy-core@${
-            config.version
-          }/dist/`;
-        } else {
-          baseUrl = "https://lib.imjoy.io/";
-        }
+        const version = config.version || "latest";
+        baseUrl = `https://cdn.jsdelivr.net/npm/imjoy-core@${version}/dist/`;
       }
       if (config.debug) {
         await _injectScript(baseUrl + "imjoy-core.js");
@@ -113,8 +108,8 @@ export function loadImJoyRPC(config) {
             return;
           }
         } else {
-          baseUrl = "https://lib.imjoy.io/";
-          version = null;
+          baseUrl = `https://cdn.jsdelivr.net/npm/imjoy-rpc@latest/dist/`;
+          version = "latest";
           console.info(`Using imjoy-rpc library from ${baseUrl}.`);
         }
       }

--- a/src/plugin-example.html
+++ b/src/plugin-example.html
@@ -8,7 +8,7 @@
     <h1>ImJoy Plugin Example</h1>
     <script src="https://lib.imjoy.io/imjoy-loader.min.js"></script>
     <script>
-      loadImJoyRPC().then(api => {
+      imjoyLoader.loadImJoyRPC().then(api => {
         function setup() {
           api.alert("ImJoy plugin initialized.");
         }

--- a/src/plugin-service-worker.js
+++ b/src/plugin-service-worker.js
@@ -31,6 +31,11 @@ if (typeof workbox !== "undefined") {
   );
 
   workbox.routing.registerRoute(
+    new RegExp("https://cdn.jsdelivr.net/npm/imjoy-rpc@.*"),
+    new workbox.strategies.StaleWhileRevalidate()
+  );
+
+  workbox.routing.registerRoute(
     new RegExp("(http|https)://lib.imjoy.io/.*"),
     new workbox.strategies.StaleWhileRevalidate()
   );


### PR DESCRIPTION
There is some issue with github pages for serving the rpc library, this PR switches to use jsdelivr cdn.