### PR TITLE
allow passing docs from plugin config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/api.js
+++ b/src/api.js
@@ -406,6 +406,7 @@ export const CONFIG_SCHEMA = ajv.compile({
     type: { type: "string", enum: Object.keys(_backends) },
     ui: { type: "string", maxLength: 2048 },
     version: { type: "string", maxLength: 32 },
+    docs: { type: ["string", "object"] },
   },
   required: [
     "name",

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -1410,7 +1410,7 @@ export class PluginManager {
       config.links = pluginComp.link || null;
       config.windows = pluginComp.window || null;
       config.styles = pluginComp.style || null;
-      config.docs = pluginComp.docs || null;
+      config.docs = pluginComp.docs || config.docs;
       config.attachments = pluginComp.attachment || null;
 
       config._id = overwrite_config._id || config.name.replace(/ /g, "_");

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -1186,9 +1186,8 @@ export class PluginManager {
       this.db
         .get(plugin_id)
         .then(doc => {
-          const pluginComp = parseComponent(doc.code);
-          const docs =
-            pluginComp.docs && pluginComp.docs[0] && pluginComp.docs[0].content;
+          const config = this.parsePluginCode(doc.code);
+          const docs = config.docs;
           resolve(docs);
         })
         .catch(err => {
@@ -1410,7 +1409,7 @@ export class PluginManager {
       config.links = pluginComp.link || null;
       config.windows = pluginComp.window || null;
       config.styles = pluginComp.style || null;
-      config.docs = pluginComp.docs || config.docs;
+      config.docs = (pluginComp.docs && pluginComp.docs[0]) || config.docs;
       config.attachments = pluginComp.attachment || null;
 
       config._id = overwrite_config._id || config.name.replace(/ /g, "_");


### PR DESCRIPTION
For imjoy-rpc app, there is no <docs> field for specifying the documentation, this PR allows passing a url to the config.