### PR TITLE
Support getting plugin from URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.23",
+  "version": "0.13.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.23",
+  "version": "0.13.24",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -2429,9 +2429,14 @@ export class PluginManager {
         );
         console.log(`${p.name} loaded.`);
         return p.api;
+      } else {
+        // try to load from plugin uri
+        const p = await this.reloadPluginRecursively({
+          uri: plugin_name,
+        });
+        console.log(`${p.name} loaded from ${plugin_name}`);
+        return p.api;
       }
-
-      throw `plugin with type ${plugin_name} not found.`;
     }
   }
 


### PR DESCRIPTION
This PR adds support for passing an plugin url to the `api.getPlugin` function.