### PR TITLE
Support create window and load plugin from source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.24",
+  "version": "0.13.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.24",
+  "version": "0.13.30",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",
@@ -102,6 +102,7 @@
     ],
     "rules": {
       "no-console": "off",
+      "no-debugger": "off",
       "no-empty": [
         "error",
         {


### PR DESCRIPTION
This PR enhance the support for dynamic plugin loading with `api.getPlugin` and `api.createWindow` (same as `api.showDialog`).

For `api.getPlugin`, you can use:
1. plugin name if the plugin is already loaded or if it's a internal plugin name (e.g. `BrowserFS`)
2. a URL/URI that point to the plugin
3. source code of the plugin

For `api.createWindow` and `api.showDialog`:
1. set `type` to a loaded window plugin
2. set `src` to a window plugin URL/URI
3. set `src` to the source code the window plugin


This enables, for example, embed a window plugin with html code inside a Python plugin, and it's more flexible to dynamically load plugins and controlled by code.
