### PR TITLE
Support api.getWindow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.33",
+  "version": "0.13.34",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.33",
+  "version": "0.13.34",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -2498,13 +2498,27 @@ export class PluginManager {
     }
   }
 
-  async getWindow(_plugin, name) {
-    for(let w of this.wm.windows){
-      if(w.name === name){
-        return w.plugin.api
-      }
+  async getWindow(_plugin, config) {
+    if (typeof config === "string") {
+      config = { name: config };
     }
-    return null
+    if (!config.name && !config.type) {
+      return null;
+    }
+    for (let w of this.wm.windows) {
+      if (config.name) {
+        if (w.name !== config.name) {
+          continue;
+        }
+      }
+      if (config.type) {
+        if (w.type !== config.type) {
+          continue;
+        }
+      }
+      return w.plugin.api;
+    }
+    return null;
   }
 
   async getFileManager(_plugin, file_manager_url) {

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -157,6 +157,7 @@ export class PluginManager {
       call: this.callPlugin,
       // getPlugins: this.getPlugins,
       getPlugin: this.getPlugin,
+      getWindow: this.getWindow,
       getFileManager: this.getFileManager,
       getEngineFactory: this.getEngineFactory,
       getEngine: this.getEngine,
@@ -2495,6 +2496,15 @@ export class PluginManager {
         return p.api;
       }
     }
+  }
+
+  async getWindow(_plugin, name) {
+    for(let w of this.wm.windows){
+      if(w.name === name){
+        return w.plugin.api
+      }
+    }
+    return null
   }
 
   async getFileManager(_plugin, file_manager_url) {

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -2512,7 +2512,7 @@ export class PluginManager {
         }
       }
       if (config.type) {
-        if (w.type !== config.type) {
+        if (w.window_type !== config.type) {
           continue;
         }
       }

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -200,6 +200,10 @@ describe("ImJoy Core", async () => {
       expect(await plugin1.api.test_close_window()).to.be.true;
     });
 
+    it("should get window", async () => {
+      expect(await plugin1.api.test_get_window()).to.be.true;
+    });
+
     it("should run plugin", async () => {
       expect(await plugin1.api.test_run()).to.be.true;
     });

--- a/tests/testWebWorkerPlugin1.imjoy.html
+++ b/tests/testWebWorkerPlugin1.imjoy.html
@@ -154,6 +154,18 @@ class ImJoyPlugin {
     })
   }
 
+  async test_get_window() {
+    const win = await api.createWindow({ name: 'new window-339',
+      type: 'Test Window Plugin',
+      data: {}
+    })
+    const win2 = await api.getWindow('new window-339')
+    assert(typeof win2.add2 === 'function')
+    const win3 = await api.getWindow({type: 'Test Window Plugin'})
+    assert(typeof win3.add2 === 'function')
+    return true
+  }
+
   async test_run() {
     const ret = await api.run('Test Web Worker Plugin 2', 199)
     assert(ret === 199)


### PR DESCRIPTION
This PR add a new api for getting the window object. `api.getWindow` can be used to get the window api by its name and/or type:
```python
w = await api.getWindow(WINDOW_NAME)

w = await api.getWindow({name: WINDOW_NAME})

w = await api.getWindow({type: WINDOW_TYPE})

w = await api.getWindow({name: WINDOW_NAME, type: WINDOW_TYPE})
```

Note this is different from `api.getPlugin` which will return a proxy plugin for all the window plugin types, the correct way to get a window (generated with `api.createWindow` or `api.showDialog`) is to call `api.getWindow`.
