### PR TITLE
Enhance service registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See [integration with ImJoy-Core](https://github.com/imjoy-team/imjoy-core/blob/
 
 ## ImJoy Core API
 
-See [api](https://github.com/imjoy-team/imjoy-core/blob/master/docs/api.md).
+See [imjoy-core api](https://github.com/imjoy-team/imjoy-core/blob/master/docs/api.md) for the detailed definition.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.37",
+  "version": "0.13.38",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.37",
+  "version": "0.13.38",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,5 @@
 import { compareVersions } from "./utils.js";
+import { serviceSpec } from "./serviceSpec.js";
 
 import Ajv from "ajv";
 export const ajv = new Ajv();
@@ -323,68 +324,13 @@ export const WINDOW_SCHEMA = ajv.compile({
   },
 });
 
-export const OP_SCHEMA = ajv.compile({
-  properties: {
-    name: { type: "string" },
-    type: { type: "string" },
-    ui: { type: ["null", "string", "array", "object"] },
-    run: { instanceof: Function },
-    inputs: { type: ["null", "object"] },
-    outputs: { type: ["null", "object"] },
-  },
-});
+export const OP_SCHEMA = ajv.compile(serviceSpec['operator']);
 
-export const ENGINE_FACTORY_SCHEMA = ajv.compile({
-  properties: {
-    name: { type: "string" },
-    type: { enum: ["engine-factory"] },
-    icon: { type: "string" },
-    url: { type: "string" },
-    config: { type: "object" },
-    addEngine: { instanceof: Function },
-    removeEngine: { instanceof: Function },
-  },
-});
+export const ENGINE_FACTORY_SCHEMA = ajv.compile(serviceSpec['engine-factory']);
 
-export const ENGINE_SCHEMA = ajv.compile({
-  properties: {
-    name: { type: "string" },
-    type: { enum: ["engine"] },
-    pluginType: { type: "string" },
-    factory: { type: "string" },
-    icon: { type: "string" },
-    url: { type: "string" },
-    config: { type: "object" },
-    connect: { instanceof: Function },
-    disconnect: { instanceof: Function },
-    listPlugins: { instanceof: Function },
-    startPlugin: { instanceof: Function },
-    getPlugin: { instanceof: Function },
-    getEngineStatus: { instanceof: Function },
-    getEngineConfig: { instanceof: [Function, null] },
-    heartbeat: { instanceof: [Function, null] },
-    killPlugin: { instanceof: [Function, null] },
-    killPluginProcess: { instanceof: [Function, null] },
-    restartPlugin: { instanceof: [Function, null] },
-    about: { instanceof: [Function, null] },
-  },
-});
+export const ENGINE_SCHEMA = ajv.compile(serviceSpec['engine']);
 
-export const FILE_MANAGER_SCHEMA = ajv.compile({
-  properties: {
-    name: { type: "string" },
-    type: { enum: ["file-manager"] },
-    url: { type: "string" },
-    shwoFileDialog: { instanceof: Function },
-    listFiles: { instanceof: Function },
-    getFile: { instanceof: Function },
-    putFile: { instanceof: Function },
-    requestUploadUrl: { instanceof: Function },
-    getFileUrl: { instanceof: Function },
-    removeFile: { instanceof: Function },
-    heartbeat: { instanceof: [Function, null] },
-  },
-});
+export const FILE_MANAGER_SCHEMA = ajv.compile(serviceSpec['file-manager']);
 
 export const CONFIG_SCHEMA = ajv.compile({
   properties: {

--- a/src/api.js
+++ b/src/api.js
@@ -324,13 +324,13 @@ export const WINDOW_SCHEMA = ajv.compile({
   },
 });
 
-export const OP_SCHEMA = ajv.compile(serviceSpec['operator']);
+export const OP_SCHEMA = ajv.compile(serviceSpec["operator"]);
 
-export const ENGINE_FACTORY_SCHEMA = ajv.compile(serviceSpec['engine-factory']);
+export const ENGINE_FACTORY_SCHEMA = ajv.compile(serviceSpec["engine-factory"]);
 
-export const ENGINE_SCHEMA = ajv.compile(serviceSpec['engine']);
+export const ENGINE_SCHEMA = ajv.compile(serviceSpec["engine"]);
 
-export const FILE_MANAGER_SCHEMA = ajv.compile(serviceSpec['file-manager']);
+export const FILE_MANAGER_SCHEMA = ajv.compile(serviceSpec["file-manager"]);
 
 export const CONFIG_SCHEMA = ajv.compile({
   properties: {

--- a/src/serviceSpec.js
+++ b/src/serviceSpec.js
@@ -1,0 +1,149 @@
+export const serviceSpec = {
+    // add your service type schema here
+    // you can use json-schema and additional keywords such as `instanceof`
+    'operator': {
+        properties: {
+            name: {
+                type: "string"
+            },
+            type: {
+                enum: ["operator"]
+            },
+            ui: {
+                type: ["null", "string", "array", "object"]
+            },
+            run: {
+                instanceof: Function
+            },
+            inputs: {
+                type: ["null", "object"]
+            },
+            outputs: {
+                type: ["null", "object"]
+            },
+        },
+    },
+    'engine-factory': {
+        properties: {
+            name: {
+                type: "string"
+            },
+            type: {
+                enum: ["engine-factory"]
+            },
+            icon: {
+                type: "string"
+            },
+            url: {
+                type: "string"
+            },
+            config: {
+                type: "object"
+            },
+            addEngine: {
+                instanceof: Function
+            },
+            removeEngine: {
+                instanceof: Function
+            },
+        },
+    },
+    'engine': {
+        properties: {
+            name: {
+                type: "string"
+            },
+            type: {
+                enum: ["engine"]
+            },
+            pluginType: {
+                type: "string"
+            },
+            factory: {
+                type: "string"
+            },
+            icon: {
+                type: "string"
+            },
+            url: {
+                type: "string"
+            },
+            config: {
+                type: "object"
+            },
+            connect: {
+                instanceof: Function
+            },
+            disconnect: {
+                instanceof: Function
+            },
+            listPlugins: {
+                instanceof: Function
+            },
+            startPlugin: {
+                instanceof: Function
+            },
+            getPlugin: {
+                instanceof: Function
+            },
+            getEngineStatus: {
+                instanceof: Function
+            },
+            getEngineConfig: {
+                instanceof: [Function, null]
+            },
+            heartbeat: {
+                instanceof: [Function, null]
+            },
+            killPlugin: {
+                instanceof: [Function, null]
+            },
+            killPluginProcess: {
+                instanceof: [Function, null]
+            },
+            restartPlugin: {
+                instanceof: [Function, null]
+            },
+            about: {
+                instanceof: [Function, null]
+            },
+        },
+    },
+    'file-manager': {
+        properties: {
+            name: {
+                type: "string"
+            },
+            type: {
+                enum: ["file-manager"]
+            },
+            url: {
+                type: "string"
+            },
+            shwoFileDialog: {
+                instanceof: Function
+            },
+            listFiles: {
+                instanceof: Function
+            },
+            getFile: {
+                instanceof: Function
+            },
+            putFile: {
+                instanceof: Function
+            },
+            requestUploadUrl: {
+                instanceof: Function
+            },
+            getFileUrl: {
+                instanceof: Function
+            },
+            removeFile: {
+                instanceof: Function
+            },
+            heartbeat: {
+                instanceof: [Function, null]
+            },
+        },
+    }
+}

--- a/src/serviceSpec.js
+++ b/src/serviceSpec.js
@@ -1,146 +1,183 @@
 export const serviceSpec = {
-    // add your service type schema here
-    // you can use json-schema and additional keywords such as `instanceof`
-    'operator': {
-        properties: {
-            name: {
-                type: "string"
-            },
-            ui: {
-                type: ["null", "string", "array", "object"]
-            },
-            run: {
-                instanceof: Function
-            },
-            inputs: {
-                type: ["null", "object"]
-            },
-            outputs: {
-                type: ["null", "object"]
-            },
-        },
+  // add your service type schema here
+  // you can use json-schema and additional keywords such as `instanceof`
+  operator: {
+    properties: {
+      name: {
+        type: "string",
+      },
+      ui: {
+        type: ["null", "string", "array", "object"],
+      },
+      run: {
+        instanceof: Function,
+      },
+      inputs: {
+        type: ["null", "object"],
+      },
+      outputs: {
+        type: ["null", "object"],
+      },
     },
-    'engine-factory': {
-        properties: {
-            name: {
-                type: "string"
-            },
-            type: {
-                enum: ["engine-factory"]
-            },
-            icon: {
-                type: "string"
-            },
-            url: {
-                type: "string"
-            },
-            config: {
-                type: "object"
-            },
-            addEngine: {
-                instanceof: Function
-            },
-            removeEngine: {
-                instanceof: Function
-            },
-        },
+  },
+  "engine-factory": {
+    properties: {
+      name: {
+        type: "string",
+      },
+      type: {
+        enum: ["engine-factory"],
+      },
+      icon: {
+        type: "string",
+      },
+      url: {
+        type: "string",
+      },
+      config: {
+        type: "object",
+      },
+      addEngine: {
+        instanceof: Function,
+      },
+      removeEngine: {
+        instanceof: Function,
+      },
     },
-    'engine': {
-        properties: {
-            name: {
-                type: "string"
-            },
-            type: {
-                enum: ["engine"]
-            },
-            pluginType: {
-                type: "string"
-            },
-            factory: {
-                type: "string"
-            },
-            icon: {
-                type: "string"
-            },
-            url: {
-                type: "string"
-            },
-            config: {
-                type: "object"
-            },
-            connect: {
-                instanceof: Function
-            },
-            disconnect: {
-                instanceof: Function
-            },
-            listPlugins: {
-                instanceof: Function
-            },
-            startPlugin: {
-                instanceof: Function
-            },
-            getPlugin: {
-                instanceof: Function
-            },
-            getEngineStatus: {
-                instanceof: Function
-            },
-            getEngineConfig: {
-                instanceof: [Function, null]
-            },
-            heartbeat: {
-                instanceof: [Function, null]
-            },
-            killPlugin: {
-                instanceof: [Function, null]
-            },
-            killPluginProcess: {
-                instanceof: [Function, null]
-            },
-            restartPlugin: {
-                instanceof: [Function, null]
-            },
-            about: {
-                instanceof: [Function, null]
-            },
-        },
+  },
+  engine: {
+    properties: {
+      name: {
+        type: "string",
+      },
+      type: {
+        enum: ["engine"],
+      },
+      pluginType: {
+        type: "string",
+      },
+      factory: {
+        type: "string",
+      },
+      icon: {
+        type: "string",
+      },
+      url: {
+        type: "string",
+      },
+      config: {
+        type: "object",
+      },
+      connect: {
+        instanceof: Function,
+      },
+      disconnect: {
+        instanceof: Function,
+      },
+      listPlugins: {
+        instanceof: Function,
+      },
+      startPlugin: {
+        instanceof: Function,
+      },
+      getPlugin: {
+        instanceof: Function,
+      },
+      getEngineStatus: {
+        instanceof: Function,
+      },
+      getEngineConfig: {
+        instanceof: [Function, null],
+      },
+      heartbeat: {
+        instanceof: [Function, null],
+      },
+      killPlugin: {
+        instanceof: [Function, null],
+      },
+      killPluginProcess: {
+        instanceof: [Function, null],
+      },
+      restartPlugin: {
+        instanceof: [Function, null],
+      },
+      about: {
+        instanceof: [Function, null],
+      },
     },
-    'file-manager': {
-        properties: {
-            name: {
-                type: "string"
-            },
-            type: {
-                enum: ["file-manager"]
-            },
-            url: {
-                type: "string"
-            },
-            shwoFileDialog: {
-                instanceof: Function
-            },
-            listFiles: {
-                instanceof: Function
-            },
-            getFile: {
-                instanceof: Function
-            },
-            putFile: {
-                instanceof: Function
-            },
-            requestUploadUrl: {
-                instanceof: Function
-            },
-            getFileUrl: {
-                instanceof: Function
-            },
-            removeFile: {
-                instanceof: Function
-            },
-            heartbeat: {
-                instanceof: [Function, null]
-            },
-        },
-    }
-}
+  },
+  "file-manager": {
+    properties: {
+      name: {
+        type: "string",
+      },
+      type: {
+        enum: ["file-manager"],
+      },
+      url: {
+        type: "string",
+      },
+      shwoFileDialog: {
+        instanceof: Function,
+      },
+      listFiles: {
+        instanceof: Function,
+      },
+      getFile: {
+        instanceof: Function,
+      },
+      putFile: {
+        instanceof: Function,
+      },
+      requestUploadUrl: {
+        instanceof: Function,
+      },
+      getFileUrl: {
+        instanceof: Function,
+      },
+      removeFile: {
+        instanceof: Function,
+      },
+      heartbeat: {
+        instanceof: [Function, null],
+      },
+    },
+  },
+  transformation: {
+    properties: {
+      name: {
+        type: "string",
+      },
+      type: {
+        enum: ["transformation"],
+      },
+      transform: {
+        instanceof: Function,
+      },
+      fit: {
+        instanceof: Function,
+      },
+      fit_transform: {
+        instanceof: Function,
+      },
+    },
+    required: ["name", "type", "transform"],
+  },
+  model: {
+    properties: {
+      name: {
+        type: "string",
+      },
+      type: {
+        enum: ["model"],
+      },
+      predict: {
+        instanceof: Function,
+      },
+      fit: {
+        instanceof: Function,
+      },
+    },
+    required: ["name", "type", "predict"],
+  },
+};

--- a/src/serviceSpec.js
+++ b/src/serviceSpec.js
@@ -6,9 +6,6 @@ export const serviceSpec = {
             name: {
                 type: "string"
             },
-            type: {
-                enum: ["operator"]
-            },
             ui: {
                 type: ["null", "string", "array", "object"]
             },

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -197,6 +197,8 @@ describe("ImJoy Core", async () => {
     });
 
     it("should register services and unregister", async () => {
+      expect(await plugin1.api.test_register_nonexist_service()).to.be.false;
+      expect(await plugin1.api.test_register_underscore_service()).to.be.true;
       const id = await plugin1.api.test_register_service();
       expect(id).to.be.a("string");
       expect(await plugin1.api.test_unregister_service(id)).to.be.true;

--- a/tests/testWebWorkerPlugin1.imjoy.html
+++ b/tests/testWebWorkerPlugin1.imjoy.html
@@ -78,7 +78,7 @@ class ImJoyPlugin {
   }
 
   async test_register() {
-    await api.register({
+    await api.registerService({
          "type": "operator",
          "name": "LUT",
          "ui": [{
@@ -96,13 +96,49 @@ class ImJoyPlugin {
   }
 
   async test_unregister() {
-    await api.unregister({'type': 'operator', 'name': 'LUT'})
+    await api.unregisterService({'type': 'operator', 'name': 'LUT'})
     return true
   }
 
+  async test_register_underscore_service() {
+    try{
+      const id = await api.registerService({
+        type: '_model123',
+        name: "my model",
+        predict: function() {}
+      })
+      await api.unregisterService({
+        id: id
+      })
+      return true
+    }
+    catch(e){
+      return false
+    } 
+  }
+  
+  async test_register_nonexist_service() {
+    try{
+      // this should throw an error
+      const id = await api.registerService({
+        type: 'model123',
+        name: "my model",
+        predict: function() {}
+      })
+      await api.unregisterService({
+        id: id
+      })
+      return true
+    }
+    catch(e){
+      return false
+    } 
+  }
+
   async test_register_service() {
-    const id = await api.register({
+    const id = await api.registerService({
       type: 'model',
+      name: 'my-model',
       predict: function() {}
     })
 
@@ -113,7 +149,7 @@ class ImJoyPlugin {
   }
 
   async test_unregister_service(id) {
-    await api.unregister({id: id});
+    await api.unregisterService({id: id});
 
     const services2 = await api.getServices({type: 'model'})
     assert(services2.length === 0, "failed to unregister model");


### PR DESCRIPTION
This PR deprecates `api.register` and `api.unregister`, and use more explicit names (`api.registerService` and `api.registerService`) instead.

`api.registerService` support built-in types (including `operator`, `engine`, `engine-factory`, `file-manager`) and contributed types (e.g. `transformation`). The list of contributed types can be extended by sending a PR to add the description to the docs and add schema to the `serviceSpec.js` file.