### PR TITLE
Support plugin namespace

### DIFF
--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -53,6 +53,8 @@ jobs:
           path: ./dist
       - name: Deploy imjoy-core to https://lib.imjoy.io
         uses: peaceiris/actions-gh-pages@v3.5.0
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
         with:
           deploy_key: ${{ secrets.ACTION_DEPLOY_KEY_FOR_LIB }}
           external_repository: imjoy-team/lib.imjoy.io

--- a/docs/api.md
+++ b/docs/api.md
@@ -1540,7 +1540,7 @@ Also notice that the content shown inside a `window` plugin do not have these re
  * fix `api.alert` display when passing an object
  * support passing plugin url or source code to `api.getPlugin`, `api.createWindow`, `api.showDialog`, which enables dynamic plugin loading
  * support passing `tag` and `namespace` to `api.getPlugin` and `api.createWindow` when constructing plugin or window from source code
- * exposing `config` to the plugin api object
+ * The plugin api object (returned from api.getPlugin, api.getWindow, api.createWindow, api.showDialog) will also include a config object which contains id, name, namespace, workspace, tag (and window_id for window plugin instance).
  
 #### api_version: 0.1.7
  * `api.fs` has been deprecated, the browser file system is moved to a separate plugin `BrowserFS`, to use the file system, you can do `const bfs_plugin = await api.getPlugin('BrowserFS'); const bfs = bfs_plugin.fs;`, now `fs` will be equivalent to `api.fs`. Notice: the data saved with `api.fs` will not be accessible with the new API, to get access the old data, please change `api_version` in the plugin config to `0.1.6`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -352,11 +352,13 @@ It contains the following fields:
     If the external web page has the ImJoy plugin api loaded, you can interact with the external website like a normal ImJoy plugin. However, if the external web page does not support ImJoy, you need to set `passive=true` to tell ImJoy that there will be no plugin api from this window.
   
   - **src**: String, specify source code to the window plugin, the url to the window plugin source code, or a url to a web app that optionally support `imjoy-rpc`. The url will treated as source code if the url ends with `.imjoy.html`, is a `gist` url or a github source code page url. Passing source code to create a window allows, for example store the source code of a window plugin inside a Python plugin, and instantiate it when needed.
+  - **tag**: String. Used with `src` to specify the tag of the plugin if the plugin support several `tags`.
+  - **namespace**: String. Used with `src` to specify the namespace of the plugin.
   - **passive**: Boolean, only used when `src` is specified. Mark whether the plugin is a passive web page (no ImJoy api exposed). Default value is `false`. 
   - **w**: Integer. Window width in grid columns (1 column = 30 pixels).
   - **h**: Integer. Window height in grid rows (1 row = 30 pixels).
-  - **data**: Object (JavaScript) or dictionary (Python). Contains data to be transferred to the window.
   - **config**: Object (JavaScript) or dictionary (Python).
+  - **data**: Object (JavaScript) or dictionary (Python). Contains data to be transferred to the window.
 
 **Returns**
 
@@ -724,7 +726,7 @@ sigma = await api.getConfig('sigma')
 
 ### api.getPlugin
 ```javascript
-plugin = await api.getPlugin(src)
+plugin = await api.getPlugin(src, config)
 ```
 
 Gets the API object of another plugin by its name, url or plugin source code.
@@ -742,6 +744,10 @@ plugin occasionally, you can also use `api.call`
 * **src**: String. Name, url or source code of another plugin. If the plugin is already loaded, then use its name, otherwise, pass a valid plugin URI or its source code. By passing the source code, it allows the flexibility of 
 embedding one or more plugin source code inside another plugin. For example, a Python plugin can dynamically populate 
 a window plugin in HTML.
+
+* **config**: Object, optional. configuration object. Currently, you can pass the following config:
+  - `tag`: String. Specify the tag of the plugin if the plugin support several `tags`, only used when `src` is the source code of the plugin.
+  - `namespace`: String. Specify the namespace of the plugin, only used when `src` is the source code of the plugin.
 
 **Returns**
 * **plugin**: Object. An object which can be used to access the plugin API functions.
@@ -1533,6 +1539,8 @@ Also notice that the content shown inside a `window` plugin do not have these re
  * support creating window or dialog from an external web page, for example:  `api.createWindow({type: "external", src: "https://kitware.github.io/itk-vtk-viewer/app", passive: true})`.
  * fix `api.alert` display when passing an object
  * support passing plugin url or source code to `api.getPlugin`, `api.createWindow`, `api.showDialog`, which enables dynamic plugin loading
+ * support passing `tag` and `namespace` to `api.getPlugin` and `api.createWindow` when constructing plugin or window from source code
+ * exposing `config` to the plugin api object
  
 #### api_version: 0.1.7
  * `api.fs` has been deprecated, the browser file system is moved to a separate plugin `BrowserFS`, to use the file system, you can do `const bfs_plugin = await api.getPlugin('BrowserFS'); const bfs = bfs_plugin.fs;`, now `fs` will be equivalent to `api.fs`. Notice: the data saved with `api.fs` will not be accessible with the new API, to get access the old data, please change `api_version` in the plugin config to `0.1.6`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.38",
+  "version": "0.13.39",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.38",
+  "version": "0.13.39",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/jailedPlugin.js
+++ b/src/jailedPlugin.js
@@ -245,6 +245,17 @@ class DynamicPlugin {
         }
         this.api = remote;
         this.api._rintf = true;
+        this.api.config = {
+          id: this.id,
+          name: this.config.name,
+          workspace: this.config.workspace,
+          type: this.config.type,
+          namespace: this.config.namespace,
+          tag: this.config.tag,
+        };
+        if (this.window_id) {
+          this.api.config.window_id = this.config.window_id;
+        }
         this._disconnected = false;
         this.initializing = false;
         this._updateUI();
@@ -339,6 +350,17 @@ class DynamicPlugin {
         await this._executePlugin();
       }
       this.api = await this._requestRemote();
+      this.api.config = {
+        id: this.id,
+        name: this.config.name,
+        workspace: this.config.workspace,
+        type: this.config.type,
+        namespace: this.config.namespace,
+        tag: this.config.tag,
+      };
+      if (this.window_id) {
+        this.api.config.window_id = this.config.window_id;
+      }
       this._disconnected = false;
       this.initializing = false;
       this._updateUI();

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -122,7 +122,6 @@ describe("ImJoy Core", async () => {
   describe("ImJoy API", async () => {
     let plugin1;
     let plugin2;
-    let pluginw;
     before(function(done) {
       this.timeout(20000);
       pm.reloadPlugin({ code: _.clone(TEST_WEB_WORKER_PLUGIN_1) }).then(p1 => {
@@ -133,30 +132,29 @@ describe("ImJoy Core", async () => {
           "op-ui-option1"
         );
         expect(typeof plugin1.api.run).to.equal("function");
-        pm.reloadPlugin({ code: _.clone(TEST_WEB_WORKER_PLUGIN_2) }).then(
-          p2 => {
-            plugin2 = p2;
-            expect(plugin2.name).to.equal("Test Web Worker Plugin 2");
-            expect(plugin2.type).to.equal("web-worker");
-            expect(typeof plugin2.api.run).to.equal("function");
+        pm.reloadPlugin({
+          code: _.clone(TEST_WEB_WORKER_PLUGIN_2),
+          namespace: "my-namespace",
+        }).then(p2 => {
+          plugin2 = p2;
+          expect(plugin2.name).to.equal("Test Web Worker Plugin 2");
+          expect(plugin2.type).to.equal("web-worker");
+          expect(typeof plugin2.api.run).to.equal("function");
+          expect(plugin2.config.namespace).to.equal("my-namespace");
+          expect(plugin2.api.config.name).to.equal("Test Web Worker Plugin 2");
+          expect(plugin2.api.config.namespace).to.equal("my-namespace");
 
-            pm.reloadPlugin({ code: _.clone(TEST_WINDOW_PLUGIN_1) }).then(
-              pw => {
-                pluginw = pw;
-                expect(pluginw.name).to.equal("Test Window Plugin");
-                expect(pluginw.type).to.equal("window");
-                expect(typeof pluginw.api.run).to.equal("function");
-                pm.createWindow(null, {
-                  name: "new window",
-                  type: "Test Window Plugin",
-                }).then(wplugin => {
-                  expect(typeof wplugin.add2).to.equal("function");
-                  done();
-                });
-              }
-            );
-          }
-        );
+          pm.createWindow(null, {
+            name: "New Window 998",
+            src: TEST_WINDOW_PLUGIN_1,
+            window_id: "my-window-998",
+          }).then(wplugin => {
+            expect(wplugin.config.name).to.equal("New Window 998");
+            expect(wplugin.config.window_id).to.equal("my-window-998");
+            expect(typeof wplugin.add2).to.equal("function");
+            done();
+          });
+        });
       });
     });
 

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -150,6 +150,7 @@ describe("ImJoy Core", async () => {
             window_id: "my-window-998",
           }).then(wplugin => {
             expect(wplugin.config.name).to.equal("New Window 998");
+            expect(wplugin.config.type).to.equal("window");
             expect(wplugin.config.window_id).to.equal("my-window-998");
             expect(typeof wplugin.add2).to.equal("function");
             done();


### PR DESCRIPTION
This PR allows accepting `namespace` and `tag` when create plugin or window with `api.getPlugin`, `api.createWindow` or `api.showDialog`.

The `namespace` is currently used for grouping plugins, for example, for grouping windows generated for each plugin in the [imjoy-fiddle](https://if.imjoy.io).

Also, the plugin api (returned from `api.getPlugin`, `api.getWindow`, `api.createWindow`, `api.showDialog`) will also include a `config` object which contains `id`, `name`, `namespace`, `workspace`, `tag` (and `window_id` for window plugin instance).

