### PR TITLE
Support passive plugin mode

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -590,7 +590,7 @@ otherwise, it will cause memory leak since the object will remain in its object 
 
 ### api.export
 
-Exports funcstions defined by the plugin as `Plugin API`.
+Exports funcstions defined by the plugin as `Plugin API`. Every imjoy plugin should export its plugin api functions, except when `passive` key under `<config>` is set to `true`.
 
 `Plugin API` can be exported as a plugin class or an object/dictionary contains all the api functions:
 
@@ -1580,6 +1580,7 @@ Also notice that the content shown inside a `window` plugin do not have these re
  * support passing `tag` and `namespace` to `api.getPlugin` and `api.createWindow` when constructing plugin or window from source code
  * The plugin api object (returned from api.getPlugin, api.getWindow, api.createWindow, api.showDialog) will also include a config object which contains id, name, namespace, workspace, tag (and window_id for window plugin instance).
  * support `api.installPlugin` and `api.uninstallPlugin`.
+ * support setting `passive` key in `<config>`.
  
 #### api_version: 0.1.7
  * `api.fs` has been deprecated, the browser file system is moved to a separate plugin `BrowserFS`, to use the file system, you can do `const bfs_plugin = await api.getPlugin('BrowserFS'); const bfs = bfs_plugin.fs;`, now `fs` will be equivalent to `api.fs`. Notice: the data saved with `api.fs` will not be accessible with the new API, to get access the old data, please change `api_version` in the plugin config to `0.1.6`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.41",
+  "version": "0.13.42",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.41",
+  "version": "0.13.42",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/api.js
+++ b/src/api.js
@@ -200,6 +200,7 @@ export const CONFIGURABLE_FIELDS = [
   "labels",
   "cover",
   "base_frame",
+  "passive",
 ];
 
 export const PLUGIN_CONFIG_FIELDS = CONFIGURABLE_FIELDS.concat([

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -1079,6 +1079,7 @@ export class PluginManager {
       if (pconfig.code) {
         const config = this.parsePluginCode(pconfig.code);
         const ps = [];
+        config.dependencies = config.dependencies || [];
         for (let i = 0; i < config.dependencies.length; i++) {
           ps.push(
             this.installPlugin(
@@ -1586,7 +1587,7 @@ export class PluginManager {
         const plugin = new DynamicPlugin(tconfig, _interface, null, true);
         plugin.api = {
           _rintf: true,
-          setup: async () => {},
+          setup: async function() {},
           run: async my => {
             const c = _clone(template.defaults) || {};
             c.type = template.name;
@@ -2493,9 +2494,12 @@ export class PluginManager {
             }
             if (pconfig.passive || window_config.passive) {
               resolve({
+                passive: true,
                 _rintf: true,
-                setup: () => {},
-                on: () => {},
+                setup: async function() {},
+                on: async function() {},
+                off: async function() {},
+                emit: async function() {},
               });
               return;
             }

--- a/tests/index_test.js
+++ b/tests/index_test.js
@@ -212,6 +212,18 @@ describe("ImJoy Core", async () => {
       expect(wm.windows.length).to.equal(count);
     });
 
+    it("should create passive window", async () => {
+      const count = wm.windows.length;
+      const w = await plugin1.api.test_create_passive_window();
+      expect(w.passive).to.be.true;
+      expect(wm.windows.length).to.equal(count + 1);
+      expect(wm.windows[wm.windows.length - 1].name).to.equal(
+        "my passive window"
+      );
+      await wm.windows[wm.windows.length - 1].close();
+      expect(wm.windows.length).to.equal(count);
+    });
+
     it("should create window", async () => {
       const count = wm.windows.length;
       expect(await plugin1.api.test_create_window()).to.be.true;
@@ -261,6 +273,11 @@ describe("ImJoy Core", async () => {
 
     it("should get plugin", async () => {
       expect(await plugin1.api.test_get_plugin()).to.be.true;
+    });
+
+    it("should get passive plugin", async () => {
+      const p = await plugin1.api.test_get_passive_plugin();
+      expect(p.passive).to.be.true;
     });
 
     it("should set/get config", async () => {

--- a/tests/testWebWorkerPlugin1.imjoy.html
+++ b/tests/testWebWorkerPlugin1.imjoy.html
@@ -168,6 +168,10 @@ class ImJoyPlugin {
     return true
   }
 
+  async test_create_passive_window() {
+    return await api.createWindow({name: 'my passive window', src: 'https://imjoy.io/static/img/loader.gif', passive: true})
+  }
+
   async test_create_window() {
     await api.createWindow({
       name: 'new window',
@@ -281,6 +285,10 @@ class ImJoyPlugin {
     return true
   }
 
+  async test_get_passive_plugin() {
+    return await api.getPlugin(await api.getAttachment("example_passive_plugin"))
+  }
+
   async test_uninstall_plugin(name) {
     await api.uninstallPlugin({
       name
@@ -392,3 +400,30 @@ class ImJoyPlugin {
 api.export(new ImJoyPlugin())
 </script>    
 </attachment>
+
+<attachment name='example_passive_plugin'>
+  <config lang="json">
+  {
+    "name": "ExamplePassivePlugin",
+    "type": "web-worker",
+    "tags": [],
+    "ui": "",
+    "version": "0.1.0",
+    "cover": "",
+    "description": "[TODO: describe this plugin with one sentence.]",
+    "icon": "extension",
+    "inputs": null,
+    "outputs": null,
+    "api_version": "0.1.8",
+    "env": "",
+    "permissions": [],
+    "requirements": [],
+    "dependencies": [],
+    "passive": true
+  }
+  </config>
+  
+  <script lang="javascript">
+  api.alert("hello");
+  </script>    
+  </attachment>


### PR DESCRIPTION
Normally, every plugin should export its plugin api, this PR allows skipping it by set the `"passive": true` in `<config>`.