### PR TITLE
Add default utils and fix html code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.50",
+  "version": "0.13.51",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.50",
+  "version": "0.13.51",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -21,6 +21,7 @@ import {
   githubUrlRaw,
   randId,
   url_regex,
+  html2string,
 } from "./utils.js";
 
 import INTERNAL_PLUGINS from "./internalPlugins.json";
@@ -111,16 +112,16 @@ export class PluginManager {
     const api_utils_ = imjoy_api.utils;
     this.imjoy_api = {
       alert: (plugin, msg) => {
-        return window.alert(msg.content || msg);
+        return window.alert(html2string(msg.content) || msg);
       },
       prompt: (plugin, msg, default_value) => {
         return window.prompt(
-          msg.content || msg,
+          html2string(msg.content) || msg,
           msg.placeholder || default_value
         );
       },
       confirm: (plugin, msg) => {
-        return window.confirm(msg.content || msg);
+        return window.confirm(html2string(msg.content) || msg);
       },
       requestUploadUrl: this.requestUploadUrl,
       getFileUrl: this.getFileUrl,

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,10 +33,13 @@ export function cacheUrlInServiceWorker(url) {
 }
 
 export function html2string(input) {
-  return input
-    .replace(/\n/gm, "")
-    .replace(/<br>/gm, "\n")
-    .replace(/<[^>]*>?/gm, "");
+  return (
+    input &&
+    input
+      .replace(/\n/gm, "")
+      .replace(/<br>/gm, "\n")
+      .replace(/<[^>]*>?/gm, "")
+  );
 }
 export function assert(condition, message) {
   if (!condition) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -32,6 +32,12 @@ export function cacheUrlInServiceWorker(url) {
   });
 }
 
+export function html2string(input) {
+  return input
+    .replace(/\n/gm, "")
+    .replace(/<br>/gm, "\n")
+    .replace(/<[^>]*>?/gm, "");
+}
 export function assert(condition, message) {
   if (!condition) {
     message = message || "Assertion failed";


### PR DESCRIPTION
This PR support default implementation of `api.utils.$forceUpdate()`, `api.utils.sleep` and `api.utils.openUrl`.

It also convert the HTML code into string in `api.alert`, `api.prompt` and `api.confirm`.