### PR TITLE
Preliminary support for hot reloading

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1435,8 +1435,12 @@ The configuration information consists of:
  * `engine`: URL of the current plugin engine. **Only available to native-python plugins**
  * `file_manager`: URL of the file manager registered by the current plugin engine. **Only available to native-python plugins**
 
-For `native-python` plugin, it contains the following additional fields:
- * `work_dir`: the current working directory
+### api.config
+The configuration information consists of:
+ * `workspace`: the current workspace.
+ * `engine`: URL of the current plugin engine. **Only available to native-python plugins**
+ * `file_manager`: URL of the file manager registered by the current plugin engine. **Only available to native-python plugins**
+
 ### api.WORKSPACE constant
 **Deprecated!** Use `api.config.workspace` instead
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.52",
+  "version": "0.13.53",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.52",
+  "version": "0.13.53",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/connection.js
+++ b/src/connection.js
@@ -48,25 +48,26 @@ export class BasicConnection extends MessageEmitter {
       }
     });
   }
-  _messageHandler(e) {
-    if (this._frame.contentWindow && e.source === this._frame.contentWindow) {
-      const target_id = e.data.target_id;
-      if (target_id && this._peer_id && target_id !== this._peer_id) {
-        const conn = all_connections[target_id];
-        if (conn) conn._fire(e.data.type, e.data);
-        else
-          console.warn(
-            `connection with target_id ${target_id} not found, discarding data: `,
-            e.data
-          );
-      } else {
-        this._fire(e.data.type, e.data);
-      }
-    }
-  }
 
   connect() {
-    window.addEventListener("message", this._messageHandler.bind(this));
+    const messageHandler = e => {
+      if (this._frame.contentWindow && e.source === this._frame.contentWindow) {
+        const target_id = e.data.target_id;
+        if (target_id && this._peer_id && target_id !== this._peer_id) {
+          const conn = all_connections[target_id];
+          if (conn) conn._fire(e.data.type, e.data);
+          else
+            console.warn(
+              `connection with target_id ${target_id} not found, discarding data: `,
+              e.data
+            );
+        } else {
+          this._fire(e.data.type, e.data);
+        }
+      }
+    };
+    this._messageHandler = messageHandler.bind(this);
+    window.addEventListener("message", this._messageHandler);
     this._fire("connected");
   }
 
@@ -118,7 +119,8 @@ export class BasicConnection extends MessageEmitter {
    * Disconnects the plugin (= kills the frame)
    */
   disconnect(details) {
-    window.removeEventListener("message", this._messageHandler);
+    if (this._messageHandler)
+      window.removeEventListener("message", this._messageHandler);
     if (!this._disconnected) {
       this._disconnected = true;
       if (typeof this._frame !== "undefined") {

--- a/src/jailedPlugin.js
+++ b/src/jailedPlugin.js
@@ -331,7 +331,6 @@ class DynamicPlugin {
       this.config.base_frame = frame_url;
     }
     const _frame = createIframe(this.config);
-    this._frame = _frame;
     if (this._hasVisibleWindow) {
       let window_id = this.config.window_id;
       if (typeof window_id === "string") {

--- a/src/jailedPlugin.js
+++ b/src/jailedPlugin.js
@@ -249,7 +249,7 @@ class DynamicPlugin {
     const engine_utils = {
       _rintf: true,
       setPluginAPI(remote) {
-        this._engineSetRemote(remote);
+        me._engineSetRemote(remote);
       },
       terminatePlugin() {
         me.terminate();

--- a/src/jailedPlugin.js
+++ b/src/jailedPlugin.js
@@ -274,12 +274,6 @@ class DynamicPlugin {
             console.warn(
               "Plugin " + this.id + " is ready, but it was termianted."
             );
-            if (this.engine && this.engine.killPlugin)
-              this.engine.killPlugin({
-                id: this.config.id,
-                name: this.config.name,
-              });
-            return;
           }
           ready(remote);
         })
@@ -326,10 +320,7 @@ class DynamicPlugin {
       this.config.base_frame = frame_url;
     }
     const _frame = createIframe(this.config);
-    const connection = new BasicConnection(_frame);
-
-    this._setupConnection(connection);
-
+    this._frame = _frame;
     if (this._hasVisibleWindow) {
       let window_id = this.config.window_id;
       if (typeof window_id === "string") {
@@ -350,6 +341,9 @@ class DynamicPlugin {
     } else {
       document.body.appendChild(_frame);
     }
+
+    const connection = new BasicConnection(_frame);
+    this._setupConnection(connection);
   }
 
   async _setupRPC(connection, pluginConfig) {
@@ -618,8 +612,6 @@ class DynamicPlugin {
     this._updateUI();
   }
   _forceDisconnect() {
-    if (this.engine && this.engine.killPlugin)
-      this.engine.killPlugin({ id: this.config.id, name: this.config.name });
     this._set_disconnected();
     if (this._rpc) {
       this._rpc.disconnect();

--- a/src/jailedPlugin.js
+++ b/src/jailedPlugin.js
@@ -196,7 +196,34 @@ class DynamicPlugin {
       }
     }
   }
-  _setupViaEngine() {
+  _engineSetRemote(remote) {
+    // check if the plugin is terminated during startup
+    if (!this.engine) {
+      console.warn("Plugin " + this.id + " is ready, but it was termianted.");
+    }
+    this.api = remote;
+    this.api._rintf = true;
+    this.api.config = {
+      id: this.id,
+      name: this.config.name,
+      workspace: this.config.workspace,
+      type: this.config.type,
+      namespace: this.config.namespace,
+      tag: this.config.tag,
+    };
+    if (this.window_id) {
+      this.api.config.window_id = this.config.window_id;
+    }
+    this._disconnected = false;
+    if (this.initializing) {
+      this.initializing = false;
+      this._updateUI();
+      this._connected.emit();
+      this.engine.registerPlugin(this);
+    }
+  }
+
+  async _setupViaEngine() {
     if (
       this.engine &&
       this.engine._is_evil &&
@@ -218,8 +245,12 @@ class DynamicPlugin {
     this.initializing = true;
     this._updateUI();
     const me = this;
+
     const engine_utils = {
       _rintf: true,
+      setPluginAPI(remote) {
+        this._engineSetRemote(remote);
+      },
       terminatePlugin() {
         me.terminate();
       },
@@ -231,33 +262,13 @@ class DynamicPlugin {
       },
     };
 
-    const ready = remote => {
-      this.api = remote;
-      this.api._rintf = true;
-      this.api.config = {
-        id: this.id,
-        name: this.config.name,
-        workspace: this.config.workspace,
-        type: this.config.type,
-        namespace: this.config.namespace,
-        tag: this.config.tag,
-      };
-      if (this.window_id) {
-        this.api.config.window_id = this.config.window_id;
-      }
-      this._disconnected = false;
-      this.initializing = false;
-      this._updateUI();
-      this._connected.emit();
-      this.engine.registerPlugin(this);
-    };
     if (this.config.passive) {
       this.engine.startPlugin(
         this.config,
         this._initialInterface,
         engine_utils
       );
-      ready({
+      this._engineSetRemote({
         passive: true,
         _rintf: true,
         setup: async function() {},
@@ -266,21 +277,21 @@ class DynamicPlugin {
         emit: async function() {},
       });
     } else {
-      this.engine
-        .startPlugin(this.config, this._initialInterface, engine_utils)
-        .then(remote => {
-          // check if the plugin is terminated during startup
-          if (!this.engine) {
-            console.warn(
-              "Plugin " + this.id + " is ready, but it was termianted."
-            );
-          }
-          ready(remote);
-        })
-        .catch(e => {
-          this.error(e);
-          this._set_disconnected();
-        });
+      try {
+        const remote = await this.engine.startPlugin(
+          this.config,
+          this._initialInterface,
+          engine_utils
+        );
+
+        // the plugin can either return the api or call engine_utils.setPluginAPI later
+        if (remote) {
+          this._engineSetRemote(remote);
+        }
+      } catch (e) {
+        this.error(e);
+        this._set_disconnected();
+      }
     }
   }
 
@@ -376,6 +387,7 @@ class DynamicPlugin {
         this._rpc.setInterface(this._initialInterface);
       }
       await this._sendInterface();
+      this._allow_execution = pluginConfig.allow_execution;
       if (pluginConfig.allow_execution) {
         await this._executePlugin();
       }
@@ -484,20 +496,47 @@ class DynamicPlugin {
     });
   }
 
+  async hotReload() {
+    if (!this.backend) {
+      this.config.hot_reloading = true;
+      await this._setupViaEngine();
+    } else {
+      if (this._allow_execution) {
+        await this._executePlugin(true);
+        if (!this.config.passive) {
+          this.api = await this._requestRemote();
+        }
+      } else {
+        throw new Error("This plugin does not allow execution.");
+      }
+    }
+  }
+
   /**
    * Loads the plugin body (executes the code in case of the
    * DynamicPlugin)
    */
-  async _executePlugin() {
+  async _executePlugin(hot_reloading) {
+    // if (hot_reloading)
+    //   await this._connection.execute({ type: "start_hot_reloading" });
     if (this.config.requirements) {
-      await this._connection.execute({
+      const requirement = {
         type: "requirements",
         lang: this.config.lang,
         requirements: this.config.requirements,
         env: this.config.env,
-      });
+      };
+      const serialized_requirement = JSON.stringify(requirement);
+      if (
+        !hot_reloading ||
+        this._executed_requirements !== serialized_requirement
+      ) {
+        await this._connection.execute(requirement);
+        this._executed_requirements = JSON.stringify(requirement);
+      }
     }
     if (this._hasVisibleWindow) {
+      // TODO: support hot-reloading of window content
       if (this.config.styles) {
         for (let i = 0; i < this.config.styles.length; i++) {
           await this._connection.execute({
@@ -530,14 +569,24 @@ class DynamicPlugin {
       }
     }
     if (this.config.scripts) {
+      const scripts = [];
+      let serialized_script = "";
       for (let i = 0; i < this.config.scripts.length; i++) {
-        await this._connection.execute({
+        const script = {
           type: "script",
           content: this.config.scripts[i].content,
           lang: this.config.scripts[i].attrs.lang,
           attrs: this.config.scripts[i].attrs,
           src: this.config.scripts[i].attrs.src,
-        });
+        };
+        serialized_script = serialized_script + JSON.stringify(script);
+        scripts.push(script);
+      }
+      if (!hot_reloading || serialized_script !== this._executed_scripts) {
+        for (let script of scripts) {
+          await this._connection.execute(script);
+        }
+        this._executed_scripts = serialized_script;
       }
     }
   }

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -2695,14 +2695,17 @@ export class PluginManager {
     }
     return ps;
   }
-
-  async getPlugin(_plugin, cfg) {
+  // TODO: deprecate the last argument
+  async getPlugin(_plugin, cfg, extra_cfg) {
     let config = {};
     if (typeof cfg === "string") {
       if (/(http(s?)):\/\//i.test(cfg) || cfg.includes("\n")) {
         config.src = cfg;
       } else {
         config.name = cfg;
+      }
+      if (extra_cfg) {
+        config = Object.assign(config, extra_cfg);
       }
     } else {
       config = cfg;

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -1081,7 +1081,6 @@ export class PluginManager {
           }
           config.origin = pconfig.origin || uri;
           config.namespace = pconfig.namespace;
-          config.hot_reloading = pconfig.hot_reloading;
           if (!config) {
             console.error(`Failed to fetch the plugin from "${uri}".`);
             reject(`Failed to fetch the plugin from "${uri}".`);
@@ -1119,7 +1118,6 @@ export class PluginManager {
                   uri: config.dependencies[i],
                   scoped_plugins: config.scoped_plugins || scoped_plugins,
                   namespace: pconfig.namespace,
-                  hot_reloading: pconfig.hot_reloading,
                 },
                 null,
                 allow_evil
@@ -1408,7 +1406,6 @@ export class PluginManager {
           _id: pconfig._id,
           origin: pconfig.origin,
           namespace: pconfig.namespace,
-          hot_reloading: pconfig.hot_reloading,
         });
 
         pconfig.name = pconfig.name || template.name;
@@ -1451,7 +1448,6 @@ export class PluginManager {
         _id: pconfig._id,
         origin: pconfig.origin,
         namespace: pconfig.namespace,
-        hot_reloading: pconfig.hot_reloading,
       });
       template.engine = null;
       this.unloadPlugin(template, true);
@@ -1464,7 +1460,6 @@ export class PluginManager {
             {
               uri: template.dependencies[i],
               namespace: pconfig.namespace,
-              hot_reloading: pconfig.hot_reloading,
             },
             null,
             allow_evil
@@ -1614,7 +1609,6 @@ export class PluginManager {
       config.uri = overwrite_config.uri;
       config.origin = overwrite_config.origin;
       config.namespace = overwrite_config.namespace;
-      config.hot_reloading = overwrite_config.hot_reloading;
       config.code = code;
       config.id = config.name.trim().replace(/ /g, "_") + "_" + randId();
       config.runnable = config.runnable === false ? false : true;

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -1081,6 +1081,7 @@ export class PluginManager {
           }
           config.origin = pconfig.origin || uri;
           config.namespace = pconfig.namespace;
+          config.hot_reloading = pconfig.hot_reloading;
           if (!config) {
             console.error(`Failed to fetch the plugin from "${uri}".`);
             reject(`Failed to fetch the plugin from "${uri}".`);
@@ -1118,6 +1119,7 @@ export class PluginManager {
                   uri: config.dependencies[i],
                   scoped_plugins: config.scoped_plugins || scoped_plugins,
                   namespace: pconfig.namespace,
+                  hot_reloading: pconfig.hot_reloading,
                 },
                 null,
                 allow_evil
@@ -1399,6 +1401,7 @@ export class PluginManager {
         _id: pconfig._id,
         origin: pconfig.origin,
         namespace: pconfig.namespace,
+        hot_reloading: pconfig.hot_reloading,
       });
       template.engine = null;
       this.unloadPlugin(template, true);
@@ -1410,6 +1413,8 @@ export class PluginManager {
           await this.reloadPluginRecursively(
             {
               uri: template.dependencies[i],
+              namespace: pconfig.namespace,
+              hot_reloading: pconfig.hot_reloading,
             },
             null,
             allow_evil
@@ -1559,6 +1564,7 @@ export class PluginManager {
       config.uri = overwrite_config.uri;
       config.origin = overwrite_config.origin;
       config.namespace = overwrite_config.namespace;
+      config.hot_reloading = overwrite_config.hot_reloading;
       config.code = code;
       config.id = config.name.trim().replace(/ /g, "_") + "_" + randId();
       config.runnable = config.runnable === false ? false : true;

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -2477,7 +2477,7 @@ export class PluginManager {
     });
   }
 
-  createWindow(_plugin, cfg) {
+  createWindow(_plugin, cfg, extra_cfg) {
     let wconfig = {};
     if (typeof cfg === "string") {
       if (
@@ -2489,6 +2489,9 @@ export class PluginManager {
       } else wconfig = { type: cfg };
     } else {
       wconfig = cfg;
+    }
+    if (extra_cfg) {
+      wconfig = Object.assign(wconfig, extra_cfg);
     }
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -1407,7 +1407,6 @@ export class PluginManager {
           origin: pconfig.origin,
           namespace: pconfig.namespace,
         });
-
         pconfig.name = pconfig.name || template.name;
         if (!plugin && pconfig.name) {
           for (let pid of Object.keys(this.plugins)) {
@@ -1418,7 +1417,7 @@ export class PluginManager {
           }
         }
 
-        if (plugin) {
+        if (plugin && plugin.type !== "window") {
           if (
             plugin.config.tag === template.tag &&
             plugin.config.engine_mode === template.engine_mode &&
@@ -1719,6 +1718,7 @@ export class PluginManager {
             c.data = (my && my.data) || {};
             c.config = (my && my.config) || {};
             c.id = my && my.id;
+            c.window_id = my && my.window_id;
             if (c.as_dialog && this.imjoy_api.showDialog) {
               // make sure there is a header and convert it to fullscreen dialog
               if (c.standalone) {

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -2704,11 +2704,11 @@ export class PluginManager {
       } else {
         config.name = cfg;
       }
-      if (extra_cfg) {
-        config = Object.assign(config, extra_cfg);
-      }
     } else {
       config = cfg;
+    }
+    if (extra_cfg) {
+      config = Object.assign(config, extra_cfg);
     }
     if (config.src && config.src.includes("\n")) {
       const p = await this.reloadPlugin({

--- a/src/pluginManager.js
+++ b/src/pluginManager.js
@@ -1498,6 +1498,7 @@ export class PluginManager {
       }
     } catch (e) {
       this.showMessage(e || "Error.", 15);
+      console.error(e);
       throw e;
     }
   }
@@ -2754,6 +2755,13 @@ export class PluginManager {
     if (typeof config === "string") {
       config = { name: config };
     }
+    if (config.window_id) {
+      for (let w of this.wm.windows) {
+        if (w.window_id === config.window_id) {
+          return w.plugin && w.plugin.api;
+        }
+      }
+    }
     if (!config.name && !config.type) {
       return null;
     }
@@ -2768,7 +2776,7 @@ export class PluginManager {
           continue;
         }
       }
-      return w.plugin.api;
+      return w.plugin && w.plugin.api;
     }
     return null;
   }


### PR DESCRIPTION
This PR allows passing a hot_reloading config to the plugin engine, this will then be used by the plugin engine.

Fixed a regression since 0.13.52, where the `getPlugin` function changed its signature and cause issue.