### PR TITLE
Fix hot-reloading error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+**0.13.72**
+ - fix(imjoyCore): Fix hot-reloading error handling
 
 **0.13.65**
  - fix(imjoyBasicApp): Fix window height when the title bar is shown

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.71",
+  "version": "0.13.72",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.71",
+  "version": "0.13.72",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/jailedPlugin.js
+++ b/src/jailedPlugin.js
@@ -517,7 +517,7 @@ class DynamicPlugin {
       this.config.hot_reloading = true;
       await this._setupViaEngine();
     } else {
-      if (!this._rpc)
+      if (!this._rpc || this._disconnected)
         throw new Error("There is no RPC connection to the plugin.");
       this.initializing = true;
       this._updateUI();
@@ -529,6 +529,7 @@ class DynamicPlugin {
           }
         } catch (error) {
           this.error(error.toString());
+          throw error
         } finally {
           this.initializing = false;
           this._updateUI();

--- a/src/jailedPlugin.js
+++ b/src/jailedPlugin.js
@@ -529,7 +529,7 @@ class DynamicPlugin {
           }
         } catch (error) {
           this.error(error.toString());
-          throw error
+          throw error;
         } finally {
           this.initializing = false;
           this._updateUI();
@@ -547,8 +547,14 @@ class DynamicPlugin {
    * DynamicPlugin)
    */
   async _executePlugin(hot_reloading) {
-    // if (hot_reloading)
-    //   await this._connection.execute({ type: "start_hot_reloading" });
+    if (hot_reloading && this.config.type === "window")
+      //clear the page
+      await this._connection.execute({
+        type: "script",
+        content: `document.querySelectorAll('style,link[rel="stylesheet"]').forEach(item => item.remove());document.body.innerHTML = '';`,
+        attrs: { type: "application/javascript" },
+        lang: "javascript",
+      });
     if (this.config.requirements) {
       const requirement = {
         type: "requirements",


### PR DESCRIPTION
This PR fixes the issue hot reloading: when there is a syntax error in the code, no error will be throw, the previous plugin will be executed instead.