### PR TITLE
Emit window size pos change event

### DIFF
--- a/src/imjoyBasicApp.js
+++ b/src/imjoyBasicApp.js
@@ -107,15 +107,21 @@ export async function loadImJoyBasicApp(config) {
       el: windowsElem,
       data: {
         type: config.window_manager_type || "standard",
-        blockPointerEvents: false,
+        windowSizePosChanging: false,
         windowStyle: config.window_style || {},
         showEmpty: config.show_empty_window || false,
         showWindowTitle: config.show_window_title || false,
         windows: [],
         activeWindow: null,
       },
+      watch: {
+        windowSizePosChanging: function(newVal) {
+          app.$emit("window-size-pos-changing", newVal);
+        },
+      },
       methods: {
         closeWindow(w) {
+          this.windowSizePosChanging = false;
           w.hidden = true;
           this.$forceUpdate();
           w.close();

--- a/src/imjoyBasicApp.template.css
+++ b/src/imjoyBasicApp.template.css
@@ -207,6 +207,6 @@ body {
   height: calc(100% - 30px);
 }
 
-.blockPointerEvents {
+.block-pointer-events {
   pointer-events: none;
 }

--- a/src/imjoyBasicAppWindows.template.html
+++ b/src/imjoyBasicAppWindows.template.html
@@ -14,13 +14,13 @@
       :width="w.w*30"
       :height="w.h*30"
       :resizable="true"
-      @resize-start="blockPointerEvents = true"
-      @resize-end="blockPointerEvents = false"
-      @move-start="blockPointerEvents = true"
-      @move-end="blockPointerEvents = false"
+      @resize-start="windowSizePosChanging = true"
+      @resize-end="windowSizePosChanging = false"
+      @move-start="windowSizePosChanging = true"
+      @move-end="windowSizePosChanging = false"
     >
       <div
-        :class="{ blockPointerEvents }"
+        :class="{'block-pointer-events': windowSizePosChanging }"
         :id="w.window_id"
         class="imjoy-window-container"
       ></div>


### PR DESCRIPTION
This event will be used for disabling pointer events in other iframe (e.g. in ImJoy-Sliders), such that the mouse won't be trapped.