### PR TITLE
Allow more 48 letters in the plugin name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.73",
+  "version": "0.13.74",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imjoy-core",
-  "version": "0.13.73",
+  "version": "0.13.74",
   "private": false,
   "description": "The core library for ImJoy -- a sandboxed plugin framework for computational web applications.",
   "author": "imjoy-team <imjoy.team@gmail.com>",

--- a/src/api.js
+++ b/src/api.js
@@ -342,7 +342,7 @@ export const CONFIG_SCHEMA = ajv.compile({
     inputs: { type: ["object", "array"] },
     labels: { type: "array", maxLength: 32 },
     lang: { type: "string", maxLength: 32 },
-    name: { type: "string", maxLength: 32 },
+    name: { type: "string", maxLength: 48 },
     outputs: { type: ["object", "array"] },
     tags: { type: "array", maxLength: 32 },
     type: { type: "string", enum: Object.keys(_backends) },


### PR DESCRIPTION
The currently limit for the letters in a plugin name is 32, when we generate a name with uuid (36 letters), it fails.